### PR TITLE
Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automatically generated documentation (I guess the DokuWiki community likes this
 Draw.io integration
 
 All documentation for this plugin can be found at
-https://lejmr.com
+https://www.dokuwiki.org/plugin:drawio and https://github.com/lejmr/dokuwiki-plugin-drawio
 
 If you install this plugin manually, make sure it is installed in
 lib/plugins/drawio/ - if the folder is called different it


### PR DESCRIPTION
Correction of the bug related to the output of the cached default diagram "Start drawing by clicking here" in other browser window, while the diagram has already been changed. Please try: 1. Create a new page. 2. Add a blank diagram to page, rename them. 3. Save a page. 4. Edit diagram (but not page!) and save them. 5. Open a page in new browser window - you will see a blank diagram "Start drawing by clicking here".