### PR TITLE
Draft support

### DIFF
--- a/action.php
+++ b/action.php
@@ -42,7 +42,7 @@
             $name = $INPUT->str('imageName');
             $action = $INPUT->str('action');
             
-            $suffix = strpos($action, "draft_") === 0 ? '.draft':'.png';
+            $suffix = strpos($action, "draft_") === 0 ? '.png.draft':'.png';
 			$media_id = $name . $suffix;
 			$media_id = cleanID($media_id);
 			$fl = mediaFN($media_id);
@@ -106,6 +106,17 @@
 					addMediaLogEntry($new, $media_id, DOKU_CHANGE_TYPE_CREATE, $lang['created'], '', null, $sizechange);
 				}
             }
+            if($action == 'get'){
+				if (!file_exists($fl)) return;
+                // Return image in the base64 for draw.io
+                $json = new JSON();
+                header('Content-Type: application/json');				
+                //$fc = file_get_contents($file_path);
+                $fc = file_get_contents($fl);
+				echo $json->encode(array("content" => "data:image/png;base64,".base64_encode($fc)));
+            }
+            
+            // Draft section
             if($action == 'draft_save'){
                 // prepare directory
                 io_createNamespace($media_id, 'media');
@@ -122,21 +133,13 @@
             }
             if($action == 'draft_get'){
                 header('Content-Type: application/json');	
+                $json = new JSON();
                 if (file_exists($fl)){
                     $fc = file_get_contents($fl);
                     echo $json->encode(array("content" => $fc));
                 }else {
                     echo $json->encode(array("content" => "NaN"));
                 }
-            }
-            if($action == 'get'){
-				if (!file_exists($fl)) return;
-                // Return image in the base64 for draw.io
-                $json = new JSON();
-                header('Content-Type: application/json');				
-                //$fc = file_get_contents($file_path);
-                $fc = file_get_contents($fl);
-				echo $json->encode(array("content" => "data:image/png;base64,".base64_encode($fc)));
             }
         }
     }

--- a/action.php
+++ b/action.php
@@ -41,8 +41,9 @@
             global $INPUT; //available since release 2012-10-13 "Adora Belle"
             $name = $INPUT->str('imageName');
             $action = $INPUT->str('action');
-			
-			$media_id = $name . '.png';
+            
+            $suffix = strpos($action, "draft_") === 0 ? '.draft':'.png';
+			$media_id = $name . $suffix;
 			$media_id = cleanID($media_id);
 			$fl = mediaFN($media_id);
 			
@@ -104,7 +105,30 @@
 				} else {
 					addMediaLogEntry($new, $media_id, DOKU_CHANGE_TYPE_CREATE, $lang['created'], '', null, $sizechange);
 				}
-			}
+            }
+            if($action == 'draft_save'){
+                // prepare directory
+                io_createNamespace($media_id, 'media');
+                
+                // Write content to file
+                $content = $INPUT->str('content');
+                //$whandle = fopen($file_path,'w');
+                $whandle = fopen($fl, 'w');
+                fwrite($whandle,base64_decode($content));
+                fclose($whandle);
+            }
+            if($action == 'draft_rm'){
+                unlink($fl);
+            }
+            if($action == 'draft_get'){
+                header('Content-Type: application/json');	
+                if (file_exists($fl)){
+                    $fc = file_get_contents($fl);
+                    echo $json->encode(array("content" => $fc));
+                }else {
+                    echo $json->encode(array("content" => "NaN"));
+                }
+            }
             if($action == 'get'){
 				if (!file_exists($fl)) return;
                 // Return image in the base64 for draw.io

--- a/action.php
+++ b/action.php
@@ -121,11 +121,13 @@
                 // prepare directory
                 io_createNamespace($media_id, 'media');
                 
-                // Write content to file
+                // Format content of draft file
+                $json = new JSON();
                 $content = $INPUT->str('content');
-                //$whandle = fopen($file_path,'w');
+                
+                // Write content to file
                 $whandle = fopen($fl, 'w');
-                fwrite($whandle,base64_decode($content));
+                fwrite($whandle, $content);
                 fclose($whandle);
             }
             if($action == 'draft_rm'){
@@ -135,8 +137,7 @@
                 header('Content-Type: application/json');	
                 $json = new JSON();
                 if (file_exists($fl)){
-                    $fc = file_get_contents($fl);
-                    echo $json->encode(array("content" => $fc));
+                    echo file_get_contents($fl);
                 }else {
                     echo $json->encode(array("content" => "NaN"));
                 }

--- a/script.js
+++ b/script.js
@@ -37,6 +37,7 @@ function edit_cb(image)
 
     var draft = localStorage.getItem('.draft-' + name);
 
+    // Prefer the draft from browser cache
     if(draft == null){
         // Try to find on-disk stored draft file
         jQuery.post(
@@ -48,10 +49,11 @@ function edit_cb(image)
             },
             function(data) {
                 if (data.content != 'NaN') {
-                    // Convert to string
-                    draft = data + "";
+                    
+                    // Set draft from received data
+                    draft = data;
 
-                    // Handle the discard
+                    // Handle the discard - remove on disk
                     if (!confirm("A version of this diagram from " + new Date(data.lastModified) + " is available. Would you like to continue editing?"))
                     {   
                         // clean draft variable
@@ -70,10 +72,10 @@ function edit_cb(image)
                 }
             }
         );
-    }
-                
-    if (draft != null)
+    } 
+    else 
     {
+
         draft = JSON.parse(draft);
                     
         if (!confirm("A version of this diagram from " + new Date(draft.lastModified) + " is available. Would you like to continue editing?"))

--- a/script.js
+++ b/script.js
@@ -120,8 +120,7 @@ function edit_cb(image)
                     {
                         call: 'plugin_drawio', 
                         imageName: imagePointer.getAttribute('id'),
-                        content: msg.xml,
-                        action: 'rmdraft'
+                        action: 'draft_rm'
                     }
                 );
                 
@@ -141,7 +140,7 @@ function edit_cb(image)
                         call: 'plugin_drawio', 
                         imageName: imagePointer.getAttribute('id'),
                         content: msg.xml,
-                        action: 'autosave'
+                        action: 'draft_save'
                     }
                 );
             }
@@ -158,7 +157,7 @@ function edit_cb(image)
                         call: 'plugin_drawio', 
                         imageName: imagePointer.getAttribute('id'),
                         content: msg.xml,
-                        action: 'autosave'
+                        action: 'draft_save'
                     }
                 );
             }

--- a/script.js
+++ b/script.js
@@ -45,6 +45,22 @@ function edit_cb(image)
         {
             draft = null;
         }
+    }else{
+
+        // Try to find on-disk stored draft file
+        jQuery.post(
+            DOKU_BASE + 'lib/exe/ajax.php',
+            {
+                call: 'plugin_drawio', 
+                imageName: imagePointer.getAttribute('id'),
+                action: 'draft_get'
+            },
+            function(data) {
+                if (data != 'NaN') return;
+                draft = data.content;
+            }
+        );
+
     }
     
     var receive = function(evt)
@@ -97,6 +113,17 @@ function edit_cb(image)
                         action: 'save'
                     }
                 );
+
+                // Remove all draft files
+                jQuery.post(
+                    DOKU_BASE + 'lib/exe/ajax.php',
+                    {
+                        call: 'plugin_drawio', 
+                        imageName: imagePointer.getAttribute('id'),
+                        content: msg.xml,
+                        action: 'rmdraft'
+                    }
+                );
                 
                 // Clean cache of this page
                 var url = new URL(window.location.href);
@@ -106,12 +133,34 @@ function edit_cb(image)
             else if (msg.event == 'autosave')
             {
                 localStorage.setItem('.draft-' + name, JSON.stringify({lastModified: new Date(), xml: msg.xml}));
+
+                // Save on-disk
+                jQuery.post(
+                    DOKU_BASE + 'lib/exe/ajax.php',
+                    {
+                        call: 'plugin_drawio', 
+                        imageName: imagePointer.getAttribute('id'),
+                        content: msg.xml,
+                        action: 'autosave'
+                    }
+                );
             }
             else if (msg.event == 'save')
             {
                 iframe.contentWindow.postMessage(JSON.stringify({action: 'export',
                     format: 'xmlpng', xml: msg.xml, spin: 'Updating page'}), '*');
                 localStorage.setItem('.draft-' + name, JSON.stringify({lastModified: new Date(), xml: msg.xml}));
+
+                // Save on-disk
+                jQuery.post(
+                    DOKU_BASE + 'lib/exe/ajax.php',
+                    {
+                        call: 'plugin_drawio', 
+                        imageName: imagePointer.getAttribute('id'),
+                        content: msg.xml,
+                        action: 'autosave'
+                    }
+                );
             }
             else if (msg.event == 'exit')
             {


### PR DESCRIPTION
Every time a drawing is modified the Draw.IO sends the updated image to the server. In case of page is accidentally restart the drawing still can be recovered from the draft image.

Drafts are saved as .png.draft file right next to the normal .png file

Implementation of #12 