### PR TITLE
Use vh unit for plugin's iframe height

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,5 +6,5 @@ iframe.drawio {
     right:0;
     bottom:0;
     width:100%;
-    height:100%
+    height:100vh
 }


### PR DESCRIPTION
Changing `%` to `vh` unit for height brought me great results - draw.io is drawn over whole website view, not just the part taken by DokuWiki container.