### PR TITLE
Edition only if ACLs permit it + filename customization + namespace customization

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,18 @@
 // Embeded editor
 var editor = 'https://www.draw.io/?embed=1&ui=atlas&spin=1&proto=json';
+
+// Default namespace for drawio images
+var imageNameSpaceTemplate = '{PAGE_NAMESPACE}:drawio'; //A subdirectory for drawio images. Example: myproject:myprojectpage:drawio
+//var imageNameSpaceTemplate = 'drawio:{PAGE_NAMESPACE}'; //A global directory for images, and a subdirectory for every project
+//var imageNameSpaceTemplate = '{PAGE_NAMESPACE}'; //Images are recorded in the page directory. Example: myproject:myprojectpage 
+
+// Default prefix filename for drawio images
+var imageNamePrefix = 'diagram_'; //Every image filename begins with
+
+// Default suffix filename for drawio images
+var imageNameSuffixTemplate = '{DATETIME}'; //Every image filename ends with date+time 
+//var imageNameSuffixTemplate = '01';
+
 var initial = null;
 var name = null;
 var imagePointer = null;
@@ -212,9 +225,12 @@ function edit_cb(image)
 
 // Toolbar menu items
 function getImageName(){
-    seq = JSINFO.id.split(":");
-    seq = seq.slice(0,seq.length-1);
-    seq.push("diagram1");
+    var dateTimeString = (new Date(Date.now()-(new Date()).getTimezoneOffset() * 60000)).toISOString().slice(0, 19).replace(/[^0-9]/g, "-"); //2020-04-11-19-15-30 
+
+    var imageNameSpace = imageNameSpaceTemplate.replace('{PAGE_NAMESPACE}', JSINFO.id); 
+    seq = imageNameSpace.split(":");
+    var imageNameSuffix = imageNameSuffixTemplate.replace('{DATETIME}', dateTimeString); 
+    seq.push(imageNamePrefix + imageNameSuffix);
     return seq.join(":");
 }
 
@@ -224,8 +240,7 @@ if (typeof window.toolbar !== 'undefined') {
         title: "",
         icon: "../../plugins/drawio/icon.png",
         key: "",
-        // open: "{{drawio>" + JSINFO.id + "}}",
-        open: "{{drawio>" + getImageName() + "}}",
+        open: "{{drawio>" + getImageName() + "}}\n",
         close: ""
     };
 };

--- a/syntax.php
+++ b/syntax.php
@@ -68,29 +68,47 @@ class syntax_plugin_drawio extends DokuWiki_Syntax_Plugin
         if ($mode !== 'xhtml') {
             return false;
         }
-		$renderer->nocache();
+        $renderer->nocache();
 
-        // Validate that the image exists otherwise pring a default image
+        // If ACLs plugin activated, image can be edited only if page can be 
+        $edit_img = true;
+        global $INFO;
+        if (isset($INFO)) {
+            $edit_img = false;
+            if ($INFO['writable'] && !$INFO['rev']) {
+                $edit_img = true;
+            }
+        }
+
+        // Validate that the image exists otherwise print a default image
         global $conf;
-		$media_id = $data . '.png';
+        $media_id = $data . '.png';
 		
-		$current_id = getID();
-		$current_ns = getNS($current_id);
+        $current_id = getID();
+        $current_ns = getNS($current_id);
 		
-		resolve_mediaid($current_ns, $media_id, $exists);
-		$diagram_id = substr($media_id, 0, -4);
+        resolve_mediaid($current_ns, $media_id, $exists);
+        $diagram_id = substr($media_id, 0, -4);
 		
         if(!$exists){
-            $renderer->doc .= "<img class='mediacenter' id='".$diagram_id."' 
-                        style='max-width:100%;cursor:pointer;' onclick='edit(this);'
-                        src='".DOKU_BASE."lib/plugins/drawio/blank-image.png' 
-                        alt='".$media_id."' />";
+            if ($edit_img) {
+                $renderer->doc .= "<img class='mediacenter' id='".$diagram_id."' 
+                style='max-width:100%;cursor:pointer;' onclick='edit(this);'
+                src='".DOKU_BASE."lib/plugins/drawio/blank-image.png' 
+                alt='".$media_id."' />";
+            }
             return true;
         }
-        $renderer->doc .= "<img class='mediacenter' id='".$diagram_id."' 
-                        style='max-width:100%;cursor:pointer;' onclick='edit(this);'
-						src='".DOKU_BASE."lib/exe/fetch.php?media=".$media_id."' 
-                        alt='".$media_id."' />";
+	
+        $renderer->doc .= "<img class='mediacenter' id='".$diagram_id."'"; 
+        $renderer->doc .= "src='".DOKU_BASE."lib/exe/fetch.php?media=".$media_id."'"; 
+        if ($edit_img) {
+            $renderer->doc .= "style='max-width:100%;cursor:pointer'; onclick='edit(this);'";
+        }
+        else {
+            $renderer->doc .= "style='max-width:100%';";
+        }
+        $renderer->doc .= "alt='".$media_id."' />";
         return true;
     }
 }


### PR DESCRIPTION
Hello.
I have created a new fork with two evolutions needed for my own business : 
1) mode "read-only" if the ACL plugin is activated and if the rule défined for the page don't allow edition.
2) ability to customize the filename or/and the namespace used for the image. It's only in the script.js.

Regards
 
