### PR TITLE
added z-index to iframe.drawio, fixes #20

### DIFF
--- a/style.css
+++ b/style.css
@@ -6,5 +6,6 @@ iframe.drawio {
     right:0;
     bottom:0;
     width:100%;
-    height:100%
+    height:100%;
+    z-index: 999;
 }


### PR DESCRIPTION
I have added `z-index: 999;` to the CSS for `iframe.drawio`.

This ensures the iframe is always visible, even if some templates use `z-index` properties to style the layout.