### PR TITLE
Feature edit button (and several fixes)

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -7,4 +7,4 @@
 $conf['zIndex']    = 999;
 $conf['url']       = 'https://embed.diagrams.net/';
 $conf['toolbar_possible_extension'] ='png';
-
+$conf['edit_button'] = false;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -7,3 +7,4 @@
 $meta['zIndex']    = array('string');
 $meta['url']       = array('string');
 $meta['toolbar_possible_extension']       = array('string');
+$meta['edit_button'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,4 +7,4 @@
 $lang['zIndex']   = 'Set zIndex for DrawIO iFrame (defaults to 999)';
 $lang['url']      = 'Set URL to draw.io instance (defaults to https://www.draw.io)';
 $lang['toolbar_possible_extension'] = "toolbar possible extension (comma-separated list)";
-
+$lang['edit_button']   = 'Show edit button at the bottom of each graph (disables edit by click).';

--- a/script.js
+++ b/script.js
@@ -6,6 +6,13 @@ var initial = null;
 var name = null;
 var imagePointer = null;
 
+function edit_button(editButton)
+{
+    var imageId = editButton.getAttribute('data-image-id');
+    var image = document.getElementById(imageId);
+    edit(image);
+}
+
 function edit(image)
 {   
     // check auth

--- a/script.js
+++ b/script.js
@@ -183,6 +183,7 @@ function edit_cb(image)
                         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
                     }).join(''));
                     var oldSvgElement = document.getElementById(image.id);
+                    var oldSvgElementOnclick = oldSvgElement.getAttribute("onclick");
                     var odlSvgParentNode = oldSvgElement.parentNode;
                     odlSvgParentNode.innerHTML = imgData;
                     var newSvgElement = odlSvgParentNode.firstElementChild;
@@ -190,9 +191,11 @@ function edit_cb(image)
                     var height = newSvgElement.getAttribute("height");
                     newSvgElement.style.width = wigth;
                     newSvgElement.style.height = height;
-                    newSvgElement.style.cursor = "pointer";
                     newSvgElement.setAttribute("class","mediacenter");
-                    newSvgElement.setAttribute('onclick','edit(this);');
+                    if (oldSvgElementOnclick != null) { // previous svg has onclick property - keep it here
+                        newSvgElement.style.cursor = "pointer";
+                        newSvgElement.setAttribute('onclick', 'edit(this);');
+                    }
                     newSvgElement.id=image.id;
                 }
                 

--- a/script.js
+++ b/script.js
@@ -170,16 +170,18 @@ function edit_cb(image)
                 {
                     // Extracts SVG DOM from data URI to enable links
                     imgData = atob(msg.data.substring(msg.data.indexOf(',') + 1));
-                    var tdElement = document.getElementById(image.id);
-                    var trElement=  tdElement.parentNode;
-                    var svgImg= document.createElement('svg');
-                    svgImg.setAttribute("class","mediacenter");
-                    svgImg.setAttribute("style","max-width:100%;cursor:pointer;");
-                    svgImg.setAttribute('onclick','edit(this);');
-                    svgImg.id=image.id;
-                    svgImg.innerHTML=imgData;
-                    trElement.replaceChild(svgImg,tdElement);
-                    trElement.style.textAlign = "center" ;
+                    var oldSvgElement = document.getElementById(image.id);
+                    var odlSvgParentNode = oldSvgElement.parentNode;
+                    odlSvgParentNode.innerHTML = imgData;
+                    var newSvgElement = odlSvgParentNode.firstElementChild;
+                    var wigth = newSvgElement.getAttribute("width");
+                    var height = newSvgElement.getAttribute("height");
+                    newSvgElement.style.width = wigth;
+                    newSvgElement.style.height = height;
+                    newSvgElement.style.cursor = "pointer";
+                    newSvgElement.setAttribute("class","mediacenter");
+                    newSvgElement.setAttribute('onclick','edit(this);');
+                    newSvgElement.id=image.id;
                 }
                 
                 localStorage.setItem(name, JSON.stringify({lastModified: new Date(), data: imgData}));

--- a/script.js
+++ b/script.js
@@ -176,7 +176,12 @@ function edit_cb(image)
                 else if (msg.format == 'svg') 
                 {
                     // Extracts SVG DOM from data URI to enable links
-                    imgData = atob(msg.data.substring(msg.data.indexOf(',') + 1));
+                    var imgBase64 = msg.data.substring(msg.data.indexOf(',') + 1);
+                    // fix utf-8 encoding problem
+                    // https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings
+                    imgData = decodeURIComponent(atob(imgBase64).split('').map(function(c) {
+                        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+                    }).join(''));
                     var oldSvgElement = document.getElementById(image.id);
                     var odlSvgParentNode = oldSvgElement.parentNode;
                     odlSvgParentNode.innerHTML = imgData;

--- a/syntax.php
+++ b/syntax.php
@@ -67,6 +67,8 @@ class syntax_plugin_drawio extends DokuWiki_Syntax_Plugin
      */
     public function render($mode, Doku_Renderer $renderer, $data)
     {
+        global $lang;
+
         if ($mode !== 'xhtml') {
             return false;
         }
@@ -99,16 +101,31 @@ class syntax_plugin_drawio extends DokuWiki_Syntax_Plugin
             $svg->addAttribute("class", "mediacenter");
             $svg->addAttribute("id", $media_id);
             $style = "width:".$width.";height:".$heigth.";";
-            $style .= "cursor:pointer";
+            if(!$this->getConf('edit_button')) {
+                $style .= "cursor:pointer;";
+                $svg->addAttribute("onclick", "edit(this);");
+            }
             $svg->addAttribute("style", $style);
-            $svg->addAttribute("onclick", "edit(this);");
             // we need parent div here to correctly replace the svg after edit
             $renderer->doc .= "<div>".$svg->asXML()."</div>";
         } else {
+            $style = "max-width:100%;";
+            $onclick = "";
+            if(!$this->getConf('edit_button')) {
+                $style .= "cursor:pointer;";
+                $onclick = "onclick='edit(this);";
+            }
             $renderer->doc .= "<img class='mediacenter' id='".$media_id."' 
-                        style='max-width:100%;cursor:pointer;' onclick='edit(this);'
+                        style='".$style."' ".$onclick."'
                         src='".DOKU_BASE."lib/exe/fetch.php?media=".$media_id."' 
                         alt='".$media_id."' />";
+        }
+
+        if($this->getConf('edit_button')) {
+            $renderer->doc .= "<button type='submit' style='display:block;font-size:75%;margin:0.5em auto 0;'
+                            data-image-id='" . $media_id . "' onclick='edit_button(this)'>
+                            ".$lang['btn_secedit']." (draw.io)
+                            </button>";
         }
         return true;
     }

--- a/syntax.php
+++ b/syntax.php
@@ -122,10 +122,14 @@ class syntax_plugin_drawio extends DokuWiki_Syntax_Plugin
         }
 
         if($this->getConf('edit_button')) {
-            $renderer->doc .= "<button type='submit' style='display:block;font-size:75%;margin:0.5em auto 0;'
+            $auth = auth_quickaclcheck(getNS($media_id).':*');
+            $auth_ow = (($conf['mediarevisions']) ? AUTH_UPLOAD : AUTH_DELETE);
+            if ($auth >= $auth_ow) {
+                $renderer->doc .= "<button type='submit' style='display:block;font-size:75%;margin:0.5em auto 0;'
                             data-image-id='" . $media_id . "' onclick='edit_button(this)'>
                             ".$lang['btn_secedit']." (draw.io)
                             </button>";
+            }
         }
         return true;
     }


### PR DESCRIPTION
This PR implements  #41 by providing new  configuration option "edit_button". Having separate edit button is very useful, mainly when you are using links in SVG images. "edit_button" config option is turn off by default, so this PR doesn't change the default plugin behaviour.

Additional PR fixes the bug with SVG displaying. SVG graphs are now displayed always using <svg> tag, not only after graph edit. Additionally correct width and height styles are applied to "<svg>" tag. Also the UTF-8 encoding problem after "live" updated of SVG graph after edit was fixed.

Finally, deprecated resolve_media_id call was replaced.

I believe that #30 might be implemented by this PR with correct SVG support.

Probably also #51 is fixed by this PR.

Since "Igor" this plugin doesn't require svgEmbed plugin to work with SVG images.
