### PR TITLE
disable caching for generated image

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -92,7 +92,7 @@ class syntax_plugin_drawio extends DokuWiki_Syntax_Plugin
         }
         $renderer->doc .= "<img class='mediacenter' id='".$media_id."' 
                         style='max-width:100%;cursor:pointer;' onclick='edit(this);'
-						src='".DOKU_BASE."lib/exe/fetch.php?media=".$media_id."' 
+						src='".DOKU_BASE."lib/exe/fetch.php?cache=nocache&media=".$media_id."' 
                         alt='".$media_id."' />";
         return true;
     }


### PR DESCRIPTION
Currently there's an issue whereby if you

  * Edit the diagram
  * Save
  * Refresh the page

After the initial save what will be shown is a dataurl, but after a refresh of the page what will be displayed is the old image.
This is due to the browser thinking that the image hasn't changed / been updated.

I think normally there's a tok parameter returned with normal images which might prevent this.
But we don't have that here.
So adding "cache=nocache&" to the call to "/lib/exe/fetch.php" seems to be one workaround.

This might be related to
https://github.com/lejmr/dokuwiki-plugin-drawio/issues/57
